### PR TITLE
Add new flag `serializeRequests` to slow down the API requests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,6 +41,18 @@ module.exports = function(grunt) {
           targetLanguages: ['fr', 'ru'],
           dest: 'tmp/'
         }]
+      },
+      serialized: {
+        options: {
+          msApiKey: process.env.MS_API_KEY,
+          serializeRequests: true
+        },
+        files: [{
+          src: 'test/fixtures/en.json',
+          sourceLanguage: 'en',
+          targetLanguages: ['de'],
+          dest: 'tmp/'
+        }]
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -58,16 +58,21 @@ grunt.initConfig({
 ```
 
 #### Full Example
-In this example, two files are being translated, one called ```locale-en.json``` and another called ```locale-fr.json```. They are in different folders, and will create translated files in the same ```i18n/``` folder.
+In this example, two files are being translated, one called
+```locale-en.json``` and another called ```locale-fr.json``` and the
+`serializeRequests` flag is enabled. They are in different folders, and will create
+translated files in the same ```i18n/``` folder.
 
-Notice how the prefix and suffix is specified, it means the translated files will be named like ```locale-de.json``` instead of ```de.json```.
+Notice how the prefix and suffix is specified, it means the translated files
+will be named like ```locale-de.json``` instead of ```de.json```.
 
 ```js
 grunt.initConfig({
     ms_translate: {
         default_options: {
             options: {
-                msApiKey: YOUR_API_KEY_HERE
+                msApiKey: YOUR_API_KEY_HERE,
+                serializeRequests: true // Serializes each request to the API; slower, but can avoid rate limit errors on free tier
             },
             files: [{
                 src: '<%= yeoman.client %>/i18n/locale-en.json',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ms-translate",
   "description": "A build task to translate JSON files to other languages using Microsoft's Translation API. Pairs very well with angular-translate.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "homepage": "https://github.com/seeq12/grunt-ms-translate",
   "author": {
     "name": "Jason Rust",

--- a/test/expected/de.json
+++ b/test/expected/de.json
@@ -1,0 +1,13 @@
+{
+  "A": "Eine",
+  "B": "Zwei",
+  "C": "Drei",
+  "D": "Vier",
+  "E": "Fünf",
+  "F": "Sechs",
+  "G": "Sieben",
+  "H": "Acht",
+  "I": "Neun",
+  "FAILURE": "Fehler beim Abrufen des data{hasError, select, true{: {message}} other{}}. Klicken Sie auf wiederholen",
+  "SUCCESS": "Erfolg {COUNT}"
+}

--- a/test/expected/ru.json
+++ b/test/expected/ru.json
@@ -8,6 +8,6 @@
   "G": "Семь",
   "H": "Восемь",
   "I": "Девять",
-  "FAILURE": "Ошибка при получении data{hasError, select, true{: {message}} other{}}. Щелкните, чтобы повторить попытку",
+  "FAILURE": "Ошибка при получении data{hasError, select, true{: {message}} other{}}. Щелкните, чтобы повторить",
   "SUCCESS": "Успех {COUNT}"
 }

--- a/test/ms_translate_test.js
+++ b/test/ms_translate_test.js
@@ -44,5 +44,14 @@ exports.ms_translate = {
     test.equal(actual, expected, 'all 11 english keys should be translated into russian, except for variables');
 
     test.done();
+  },
+  serialized_german: function(test) {
+    test.expect(1);
+
+    const actual = grunt.file.read('tmp/de.json');
+    const expected = grunt.file.read('test/expected/de.json');
+    test.equal(actual, expected, 'all 11 english keys should be translated into german, except for variables');
+
+    test.done();
   }
 };


### PR DESCRIPTION
This flag can help mitigate API error responses about the rate limit
being exceeded, especially when used on the free tier.